### PR TITLE
feat: Implement Google Sign-In with hidden button

### DIFF
--- a/src/app/features/auth/login/login.component.html
+++ b/src/app/features/auth/login/login.component.html
@@ -182,7 +182,7 @@
         </div>
 
         <div class="social-buttons" *ngIf="iconsRegistered">
-          <button mat-stroked-button class="social-button" aria-label="Sign in with Google" i18n-aria-label="@@signInWithGoogleAriaLabel">
+          <button mat-stroked-button class="social-button" (click)="signInWithGoogle()" aria-label="Sign in with Google" i18n-aria-label="@@signInWithGoogleAriaLabel">
             <mat-icon svgIcon="google"></mat-icon>
           </button>
           <button mat-stroked-button class="social-button" aria-label="Sign in with Facebook" i18n-aria-label="@@signInWithFacebookAriaLabel">
@@ -192,6 +192,7 @@
             <mat-icon svgIcon="apple"></mat-icon>
           </button>
         </div>
+        <div id="googleSignInHiddenButton" style="position: absolute; left: -9999px; top: -9999px; width: 250px; height: 50px; opacity: 0;"></div>
 
         <div class="dark-mode-toggle-container" *ngIf="iconsRegistered">
           <mat-slide-toggle [checked]="(themeService.isDarkMode$ | async)!" (change)="toggleDarkMode()" i18n="@@darkModeLabel">

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,7 @@
     />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
   </head>
   <body class="mat-typography">
     <app-root></app-root>


### PR DESCRIPTION
This commit implements Google Sign-In using the Google Identity Services (GIS) library, while keeping the existing Angular Material button's appearance.

- Adds the GIS library to `index.html`.
- Modifies the login component to include a hidden div for the GIS button.
- Implements the `ngAfterViewInit` lifecycle hook to initialize GIS.
- Adds a `signInWithGoogle` method to programmatically trigger the Google Sign-In flow.
- Adds a `handleGoogleSignIn` callback to handle the response from Google.